### PR TITLE
fix python dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
       "."
     ],
     "dependencies": {
-      "xbox-smartglass-core": ">=1.3.0"
+      "xbox-smartglass-core": ">=1.2.2"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
fix : 

```
Update xbox from @0.6.8 to @0.7.0
NPM version: 6.14.8
npm install iobroker.xbox@0.7.0 --loglevel error --unsafe-perm --prefix "/opt/iobroker" (System call)
  Cache entry deserialization failed, entry ignored
ERROR: Could not find a version that satisfies the requirement xbox-smartglass-core>=1.3.0 (from versions: 1.0.2, 1.0.3, 1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.10, 1.0.11, 1.0.12, 1.1.0, 1.1.1, 1.1.2, 1.2.0, 1.2.1, 1.2.2)
ERROR: No matching distribution found for xbox-smartglass-core>=1.3.0
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! iobroker.xbox@0.7.0 install: `npip install`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the iobroker.xbox@0.7.0 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/iobroker/.npm/_logs/2020-11-18T21_31_08_090Z-debug.log
host.ioBroker Cannot install iobroker.xbox@0.7.0: 1
```